### PR TITLE
bulk creation of gamePref records

### DIFF
--- a/public/js/board-game-atlas-api.js
+++ b/public/js/board-game-atlas-api.js
@@ -200,14 +200,17 @@ $("#save-profile-button").on("click", function (event) {
       if (list.length > 0) {
         // Post GamePref data via AJAX
         $.ajax("/api/gameprefs", {
+          headers: {
+            "Content-Type": "application/json"
+          },
           type: "POST",
-          data: list[0]
+          data: JSON.stringify(list)
         }).then(
           function() {
             console.log("added new GamePrefs");
 
           // load the matches page
-          window.location.href = "/matches";
+          window.location.href = "/matches"; 
         });
       }
     }

--- a/routes/apiGamePrefRoutes.js
+++ b/routes/apiGamePrefRoutes.js
@@ -11,17 +11,8 @@ module.exports = function(app) {
   });
 
   // Create new GamePref(s)
-  /*app.post("/api/gameprefs", function(req, res) {
-    console.log(req.body);
-    console.log(JSON.parse(req.body));
-    db.GamePref.bulkCreate(req.body.list).then(function(dbGamePref) {
-      res.json(dbGamePref);
-    });
-  });*/
-
-  // Create new GamePref(s)
   app.post("/api/gameprefs", function(req, res) {
-    db.GamePref.create(req.body).then(function(dbGamePref) {
+    db.GamePref.bulkCreate(req.body).then(function(dbGamePref) {
       res.json(dbGamePref);
     });
   });


### PR DESCRIPTION
Before, the /profileCreation page would only add one of the games you selected to your profile... but I figured out how to use the bulkCreate Sequelize function to add any number of records at once.